### PR TITLE
Add a-circle component to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Vue.config.ignoredElements = [
   'a-cursor',
   'a-gltf-model',
   'a-triangle',
-  'a-cubemap'
+  'a-cubemap',
+  'a-circle'
 ]
 ```


### PR DESCRIPTION
I used this list of components, but today I realized that the a-circle was giving me errors in the console since it is not in this list.